### PR TITLE
fix: Do not attempt fix mod with wrong folder name

### DIFF
--- a/src/core/manage.rs
+++ b/src/core/manage.rs
@@ -192,14 +192,6 @@ where
                         debug!("Add submod {}", name);
                         mods.push(Path::new("mods").join(name));
                     }
-                } else {
-                    // sometimes people don't use the `mods` folder if they only have one mod
-                    // this is technically incorrect but we should handle it anyways
-                    debug!(
-                        "Add one submod {}",
-                        e.path().file_name().unwrap().to_string_lossy()
-                    );
-                    mods.push(PathBuf::new());
                 }
             }
         }


### PR DESCRIPTION
Do not attempt to fix a mod that might have their Northstar mods in a folder that isn't called `mods/`.

In particular the removal of this functionality is done as it breaks https://northstar.thunderstore.io/package/EladNLG/HUDRevamp/2.0.0/ due to it containing a second folder in root dir called `assets/` which is incorrectly picked up as a `mods` folder and then later errors out due to not containing a `mod.json`.

Related: https://github.com/R2NorthstarTools/FlightCore/issues/406