### PR TITLE
refactor: Rename consts to specifically specify Titanfall2

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -276,7 +276,7 @@ pub(crate) mod steam {
     use std::path::PathBuf;
     use steamlocate::SteamDir;
 
-    use crate::TITANFALL_STEAM_ID;
+    use crate::TITANFALL2_STEAM_ID;
 
     /// Returns the path to the Steam installation if it exists
     #[must_use]
@@ -297,7 +297,7 @@ pub(crate) mod steam {
     #[must_use]
     pub fn titanfall() -> Option<PathBuf> {
         let mut steamdir = SteamDir::locate()?;
-        Some(steamdir.app(&TITANFALL_STEAM_ID)?.path.clone())
+        Some(steamdir.app(&TITANFALL2_STEAM_ID)?.path.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ pub const CORE_MODS: [&str; 3] = [
     "northstar.client",
 ];
 
-pub const TITANFALL_STEAM_ID: u32 = 1237970;
-pub const TITANFALL_ORIGIN_IDS: [&str; 2] = ["Origin.OFR.50.0001452", "Origin.OFR.50.0001456"];
+pub const TITANFALL2_STEAM_ID: u32 = 1237970;
+pub const TITANFALL2_ORIGIN_IDS: [&str; 2] = ["Origin.OFR.50.0001452", "Origin.OFR.50.0001456"];
 
 // Important functions and structs
 pub mod prelude {
@@ -44,5 +44,5 @@ pub mod prelude {
     pub use crate::core::{steam_dir, steam_libraries, titanfall};
     pub use crate::error::ThermiteError;
     pub use crate::CORE_MODS;
-    pub use crate::TITANFALL_STEAM_ID;
+    pub use crate::TITANFALL2_STEAM_ID;
 }


### PR DESCRIPTION
Renames
- `TITANFALL_STEAM_ID` to `TITANFALL2_STEAM_ID`
- `TITANFALL_ORIGIN_IDS` to `TITANFALL2_ORIGIN_IDS`

This is done as `Titanfall` technically implies the first game which is also on Steam and Origin. I'm aware that `libthermite` only targets Titanfall2 but just adding a `2` to the variable name doesn't really increase the name length while helping a lot with proper namespacing ^^

Would technically require a major version bump on release due to the current interface already being public.